### PR TITLE
feat: Enhance FDG with multiple interpolation methods

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -57,45 +57,64 @@ def laplacian_guidance(
     return pred_guided.to(pred_cond.dtype)
 
 
-def create_linear_guidance_scale(high_scale, low_scale, levels):
-    """Creates linearly interpolated guidance scale array."""
+def create_guidance_scales(high_scale, low_scale, levels, interpolation_type="linear"):
+    """Creates interpolated guidance scale array."""
     if levels == 1:
         return [high_scale]
-    
-    """Linear interpolation of guidance between levels."""
-    scales = torch.linspace(high_scale, low_scale, levels).tolist()
-    return scales
+
+    scales = torch.zeros(levels)
+    if interpolation_type == "linear":
+        scales = torch.linspace(high_scale, low_scale, levels)
+    elif interpolation_type == "cosine":
+        # Cosine interpolation from high_scale down to low_scale
+        for i in range(levels):
+            t = i / (levels - 1) if levels > 1 else 0
+            cosine_t = (1 - math.cos(t * math.pi)) / 2  # ranges 0 to 1
+            scales[i] = high_scale * (1 - cosine_t) + low_scale * cosine_t
+    elif interpolation_type == "quadratic_ease_in":
+        # Eases in (starts slow, ends fast)
+        for i in range(levels):
+            t = i / (levels - 1) if levels > 1 else 0
+            scales[i] = high_scale + (low_scale - high_scale) * (t ** 2)
+    elif interpolation_type == "quadratic_ease_out":
+        # Eases out (starts fast, ends slow)
+        for i in range(levels):
+            t = i / (levels - 1) if levels > 1 else 0
+            scales[i] = high_scale + (low_scale - high_scale) * (1 - (1 - t) ** 2)
+    elif interpolation_type == "step":
+        mid_point = levels // 2
+        scales[:mid_point] = high_scale
+        scales[mid_point:] = low_scale
+        if levels == 1: # Ensure single level gets high_scale
+             scales[0] = high_scale
+    else: # Default to linear
+        scales = torch.linspace(high_scale, low_scale, levels)
+
+    return scales.tolist()
+
+def create_parallel_weights(high_weight, low_weight, levels, interpolation_type="linear"):
+    """Creates interpolated parallel weights array."""
+    # Using the same logic as create_guidance_scales for now
+    # Potentially could have different/simpler interpolation for weights
+    return create_guidance_scales(high_weight, low_weight, levels, interpolation_type)
+
 
 class FDGNode:
+    INTERPOLATION_TYPES = ["linear", "cosine", "quadratic_ease_in", "quadratic_ease_out", "step"]
+
     @classmethod
     def INPUT_TYPES(s):
         return {
             "required": {
                 "model": ("MODEL",),
-                "guidance_scale_high": ("FLOAT", {
-                    "default": 7.5, 
-                    "min": 1.0, 
-                    "max": 20.0, 
-                    "step": 0.1
-                }),
-                "guidance_scale_low": ("FLOAT", {
-                    "default": 1.0, 
-                    "min": 1.0, 
-                    "max": 20.0, 
-                    "step": 0.1
-                }),
-                "levels": ("INT", {
-                    "default": 2,
-                    "min": 2,
-                    "max": 4,
-                    "step": 1
-                }),
-                "fdg_steps": ("INT", {
-                    "default": 2,
-                    "min": 1,
-                    "max": 50,
-                    "step": 1
-                })
+                "guidance_scale_high": ("FLOAT", {"default": 7.5, "min": 0.0, "max": 100.0, "step": 0.1}),
+                "guidance_scale_low": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 100.0, "step": 0.1}),
+                "levels": ("INT", {"default": 3, "min": 1, "max": 8, "step": 1}), # Min levels 1 now
+                "scale_interpolation": (s.INTERPOLATION_TYPES, {"default": "linear"}),
+                "parallel_weight_high": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 2.0, "step": 0.05}),
+                "parallel_weight_low": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 2.0, "step": 0.05}),
+                "weight_interpolation": (s.INTERPOLATION_TYPES, {"default": "linear"}),
+                "fdg_steps": ("INT", {"default": 2, "min": 0, "max": 1000, "step": 1}) # fdg_steps 0 means FDG off
             }
         }
     
@@ -103,11 +122,30 @@ class FDGNode:
     FUNCTION = "patch"
     CATEGORY = "advanced/model"
     
-    def patch(self, model, guidance_scale_high, guidance_scale_low, levels, fdg_steps):
+    def patch(self, model, guidance_scale_high, guidance_scale_low, levels, scale_interpolation,
+              parallel_weight_high, parallel_weight_low, weight_interpolation, fdg_steps):
         
-        """Create guidance scales and parallel weights arrays"""
-        guidance_scale = create_linear_guidance_scale(guidance_scale_high, guidance_scale_low, levels)
-        parallel_weights = [1.0] * (levels)
+        if fdg_steps == 0: # Allow disabling FDG
+            m = model.clone()
+            # To fully disable, we might need to ensure no cfg function is set or a default one.
+            # For now, returning the original model if no steps are to be FDG'd.
+            # Or, ensure fdg_function respects this by only applying CFG.
+            # The current fdg_function already handles CFG if sigma is outside fdg_steps range,
+            # so fdg_steps = 0 effectively means it always uses else branch (standard CFG).
+            # However, the set_model_sampler_cfg_function is still called.
+            # A cleaner way might be to not patch if fdg_steps is 0.
+            # For now, the existing logic within fdg_function should suffice.
+            pass
+
+
+        guidance_scale = create_guidance_scales(guidance_scale_high, guidance_scale_low, levels, scale_interpolation)
+        parallel_weights = create_parallel_weights(parallel_weight_high, parallel_weight_low, levels, weight_interpolation)
+
+        if not guidance_scale: # Should not happen if levels >= 1
+            guidance_scale = [guidance_scale_high]
+        if not parallel_weights:
+            parallel_weights = [parallel_weight_high]
+
         def fdg_function(args):
             cond = args["cond"]
             uncond = args["uncond"]

--- a/readme.md
+++ b/readme.md
@@ -3,27 +3,52 @@ Implementation of [Guidance in the Frequency Domain Enables High-Fidelity Sampli
 
 Thanks to the FDG researchers for making their code public.
 
-FDG improves image quality at low guidance scales and avoids the drawbacks of high CFG scales by design.
+FDG improves image quality at low guidance scales and avoids the drawbacks of high CFG scales by design. This implementation expands upon the basic concept by offering flexible interpolation methods for guidance strengths and parallel component weights across frequency levels.
 
 Paper: https://arxiv.org/abs/2506.19713
 
-
-
-
 ## Usage
 
-To use FDG, just place the `FDGNode` (located in the advanced/model category) in front of the `KSampler` node in your workflow.
+To use FDG, place the `FDGNode` (located in the `advanced/model` category) in front of the `KSampler` node in your workflow. The FDG node patches the model to apply frequency-decoupled guidance. Note that the CFG value set in the KSampler will be used by FDG if `fdg_steps` is configured to switch to standard CFG, or if `fdg_steps` is 0.
 
-Basically disables cfg values ​​within KSampler.
-
-Testing on SDXL only.
+Testing primarily on SDXL.
 
 ## Inputs
 
-- `guidance_scale_high`: Guidance scale for high-frequency details.
-- `guidance_scale_low`: Guidance scale for low-frequency structures.
-- `levels`: Number of pyramid levels for frequency decomposition. For levels higher than 2, it operates using linear interpolation for each frequency.
-- `fdg_steps`:  Number of initial steps where FDG is applied before switching to CFG. Beyond this threshold, the cfg value from the KSampler node takes effect. When cfg equals 1, the guidance_scale_high value is used. If the threshold exceeds the total number of steps, FDG is automatically applied to all steps.
+The `FDGNode` provides the following input parameters:
+
+-   **`model`**: The model to patch with FDG.
+-   **`guidance_scale_high`**: (Float, Default: 7.5)
+    The guidance strength applied to the highest frequency components (finest details).
+-   **`guidance_scale_low`**: (Float, Default: 1.0)
+    The guidance strength applied to the lowest frequency components (coarsest structures).
+-   **`levels`**: (Int, Default: 3, Min: 1, Max: 8)
+    Number of pyramid levels for frequency decomposition. More levels mean finer frequency bands.
+    - If `levels` is 1, `guidance_scale_high` and `parallel_weight_high` are used for all frequencies.
+-   **`scale_interpolation`**: (Enum, Default: "linear")
+    The interpolation method used to transition from `guidance_scale_high` to `guidance_scale_low` across the frequency `levels`.
+    Options:
+    -   `linear`: Smooth linear transition.
+    -   `cosine`: Cosine curve for smoother transition.
+    -   `quadratic_ease_in`: Starts slow, accelerates towards `guidance_scale_low`. High frequencies get stronger guidance for more levels.
+    -   `quadratic_ease_out`: Starts fast, decelerates towards `guidance_scale_low`. High frequencies quickly transition away from `guidance_scale_high`.
+    -   `step`: Applies `guidance_scale_high` to the first half of levels and `guidance_scale_low` to the second half. A more direct split.
+-   **`parallel_weight_high`**: (Float, Default: 1.0, Min: 0.0, Max: 2.0)
+    The weight for the component of guidance that is parallel to the conditional prediction, applied at the highest frequency.
+    - A weight of 1.0 uses the parallel component unmodified.
+    - A weight > 1.0 amplifies the parallel component.
+    - A weight < 1.0 dampens the parallel component, relatively increasing the influence of the orthogonal component.
+    - A weight of 0.0 uses only the orthogonal component for guidance at this frequency extreme.
+-   **`parallel_weight_low`**: (Float, Default: 1.0, Min: 0.0, Max: 2.0)
+    The weight for the parallel component of guidance, applied at the lowest frequency.
+-   **`weight_interpolation`**: (Enum, Default: "linear")
+    The interpolation method used to transition from `parallel_weight_high` to `parallel_weight_low` across frequency `levels`. Uses the same options as `scale_interpolation`.
+-   **`fdg_steps`**: (Int, Default: 2, Min: 0, Max: 1000)
+    Number of initial sampling steps where FDG is applied.
+    - Beyond this step count (approximated by sigma values), standard Classifier-Free Guidance (CFG) using the KSampler's CFG value is applied.
+    - If `fdg_steps` is 0, FDG is effectively disabled, and standard CFG is used for all steps (though the model is still patched).
+    - If `fdg_steps` is very high (e.g., exceeds total sampling steps), FDG is applied to all steps.
+    - When FDG switches to standard CFG, or if `fdg_steps` is 0, and the KSampler's CFG value is 1.0, the `guidance_scale_high` value from this node is used as the CFG scale by the internal FDG logic. This specific behavior for CFG=1 is a nuance of the underlying `fdg_function`.
 
 ## Citation
 


### PR DESCRIPTION
This commit introduces several improvements to the Frequency Decoupled Guidance (FDG) node:

- New interpolation methods for guidance scales:
    - linear (original)
    - cosine
    - quadratic_ease_in
    - quadratic_ease_out
    - step This allows for more nuanced control over how guidance strength is applied across different frequency levels.

- Controllable parallel weights:
    - New parameters `parallel_weight_high` and `parallel_weight_low` allow defining weights for the component of guidance parallel to the conditional prediction at frequency extremes.
    - Interpolation for these weights can also be selected using `weight_interpolation` (with the same methods as scale interpolation). This enables experimentation with emphasizing or de-emphasizing the learned manifold's direction at different frequencies.

- Node parameter updates:
    - `levels` now supports a minimum of 1 (for single-band guidance).
    - `fdg_steps` now supports a minimum of 0 (to effectively disable FDG and use standard CFG).

- Documentation (`readme.md`) has been updated to reflect these new features and parameters.